### PR TITLE
Upgrade to .NET 9.0 across configurations and Dockerfiles

### DIFF
--- a/.github/workflows/buildwindowsimage.yml
+++ b/.github/workflows/buildwindowsimage.yml
@@ -14,6 +14,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.4
+  
+    - name: Install NET 9
+      uses: actions/setup-dotnet@v4.0.1
+      with:
+        dotnet-version: '9.0.x'
 
     - name: Get the version
       id: get_version

--- a/.github/workflows/createrelease.yml
+++ b/.github/workflows/createrelease.yml
@@ -19,10 +19,10 @@ jobs:
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
-    - name: Install NET 8
-      uses: actions/setup-dotnet@v2
+    - name: Install NET 9
+      uses: actions/setup-dotnet@v4.0.1
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
 
     - name: Restore Nuget Packages
       run: dotnet restore MobileConfiguration.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }}

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -19,10 +19,10 @@ jobs:
     - name: Set Up Variables
       run: echo "action_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_ENV
 
-    - name: Install NET 8
-      uses: actions/setup-dotnet@v2
+    - name: Install NET 9
+      uses: actions/setup-dotnet@v4.0.1
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
 
     - name: Restore Nuget Packages
       run: dotnet restore MobileConfiguration.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
 
-    - name: Install NET 8
-      uses: actions/setup-dotnet@v2
+    - name: Install NET 9
+      uses: actions/setup-dotnet@v4.0.1
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
 
     - name: Restore Nuget Packages
       run: dotnet restore MobileConfiguration.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }}

--- a/.github/workflows/pushtomaster.yml
+++ b/.github/workflows/pushtomaster.yml
@@ -19,10 +19,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install NET 8
-      uses: actions/setup-dotnet@v2
+    - name: Install NET 9
+      uses: actions/setup-dotnet@v4.0.1
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
 
     - name: Restore Nuget Packages
       run: dotnet restore MobileConfiguration.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }}

--- a/MobileConfiguration/Dockerfile
+++ b/MobileConfiguration/Dockerfile
@@ -1,7 +1,7 @@
 FROM stuartferguson/txnprocbase AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY ["MobileConfiguration/NuGet.Config", "MobileConfiguration/"]
 COPY ["MobileConfiguration/MobileConfiguration.csproj", "MobileConfiguration/"]

--- a/MobileConfiguration/Dockerfilewindows
+++ b/MobileConfiguration/Dockerfilewindows
@@ -2,7 +2,7 @@ FROM stuartferguson/txnprocbasewindows AS base
 USER ContainerAdministrator
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-windowsservercore-ltsc2022 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2022 AS build
 WORKDIR /src
 COPY ["MobileConfiguration/NuGet.Config", "MobileConfiguration/"]
 COPY ["MobileConfiguration/MobileConfiguration.csproj", "MobileConfiguration/"]

--- a/MobileConfiguration/MobileConfiguration.csproj
+++ b/MobileConfiguration/MobileConfiguration.csproj
@@ -1,32 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>8795d0e9-2509-41b8-b1e1-f28f8468338b</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.3">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.8" />
-    <PackageReference Include="Shared" Version="2024.7.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="5.5.0" />
+    <PackageReference Include="Shared" Version="2025.6.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.3" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This commit updates the .NET version from 8.0 to 9.0 in multiple YAML configuration files, including `buildwindowsimage.yml`, `createrelease.yml`, `nightlybuild.yml`, `pullrequest.yml`, and `pushtomaster.yml`. The Dockerfiles have also been modified to use the .NET 9.0 SDK images. Additionally, the `MobileConfiguration.csproj` file has been updated to target .NET 9.0, with package references updated to their respective 9.0 versions for compatibility.

Closes #37 